### PR TITLE
replace html tags with bbcodes

### DIFF
--- a/files/lib/system/exporter/WordPress3xExporter.class.php
+++ b/files/lib/system/exporter/WordPress3xExporter.class.php
@@ -283,7 +283,7 @@ class WordPress3xExporter extends AbstractExporter {
 				'message' => self::fixMessage($row['post_content']),
 				'time' => $time,
 				'comments' => $row['comment_count'],
-				'enableSmilies' => 0,
+				'enableSmilies' => 1,
 				'enableHtml' => 0,
 				'enableBBCodes' => 1,
 				'isPublished' => ($row['post_status'] == 'publish' ? 1 : 0),

--- a/files/lib/system/exporter/WordPress3xExporter.class.php
+++ b/files/lib/system/exporter/WordPress3xExporter.class.php
@@ -284,8 +284,8 @@ class WordPress3xExporter extends AbstractExporter {
 				'time' => $time,
 				'comments' => $row['comment_count'],
 				'enableSmilies' => 0,
-				'enableHtml' => 1,
-				'enableBBCodes' => 0,
+				'enableHtml' => 0,
+				'enableBBCodes' => 1,
 				'isPublished' => ($row['post_status'] == 'publish' ? 1 : 0),
 				'isDeleted' => ($row['post_status'] == 'trash' ? 1 : 0)
 			), $additionalData);
@@ -417,7 +417,193 @@ class WordPress3xExporter extends AbstractExporter {
 	}
 	
 	private static function fixMessage($string) {
-		$string = str_replace("\n", "<br />\n", StringUtil::unifyNewlines($string));
+		
+		// we wanna get rid of f*ckin html in articles, so we have to remove a lot of crap
+		// btw. I hate this stuff and I'm pretty sure a lot of ppl. could do this much better
+		// really guys, I have no idea what I'm doing
+		// however, lets go...
+		
+		// <hr /> tags
+		$string = str_ireplace('<hr />', '', $string);
+		
+		// new lines
+		$string = str_replace("\n\n\n", "\n\n", StringUtil::unifyNewlines($string));
+		$string = str_ireplace('<br />', "\n", $string);
+		$string = str_ireplace('<br>', "\n", $string);
+		
+		// quotes
+		$string = preg_replace('~<blockquote[^>]*>(.*?)</blockquote>~is', '[quote]\\1[/quote]', $string);
+		
+		// read more
+		$string = str_ireplace('<!--more-->', '', $string);
+		
+		// deleted
+		$string = preg_replace('~<del[^>]*>(.*?)</del>~is', '[s]\\1[/s]', $string);
+		
+		// list
+		$string = str_ireplace('<ul style="list-style-type: circle;">', '[list]', $string);
+		$string = str_ireplace('<ul>', '[list]', $string);
+		$string = str_ireplace('</ul>', '[/list]', $string);
+		$string = str_ireplace('<li>', '[*]', $string);
+		$string = str_ireplace('</li>', '', $string);
+		$string = str_ireplace('<ol>', '[list=1]', $string);
+		$string = str_ireplace('</ol>', '[/list]', $string);
+		
+		// code
+		$string = preg_replace('~<code[^>]*>(.*?)</code>~is', '[code]\\1[/code]', $string);
+		$string = preg_replace('~<pre[^>]*>(.*?)</pre>~is', '[code]\\1[/code]', $string);
+		
+		// non-breaking space
+		$string = str_ireplace('&nbsp;', '', $string);
+		
+		// bold
+		$string = preg_replace('~(<strong)\b[^>]*?(?=\h*\/?>)~','\1', $string);
+		$string = str_ireplace('<strong>', '[b]', $string);
+		$string = str_ireplace('</strong>', '[/b]', $string);
+		$string = str_ireplace('<b>', '[b]', $string);
+		$string = str_ireplace('</b>', '[/b]', $string);
+		
+		// italic
+		$string = preg_replace('~(<i)\b[^>]*?(?=\h*\/?>)~','\1', $string);
+		$string = preg_replace('~(<em)\b[^>]*?(?=\h*\/?>)~','\1', $string);
+		$string = str_ireplace('<em>', '[i]', $string);
+		$string = str_ireplace('</em>', '[/i]', $string);
+		$string = str_ireplace('<i>', '[i]', $string);
+		$string = str_ireplace('</i>', '[/i]', $string);
+		
+		// color
+		$string = preg_replace('~<span style="color: (.*?);?">(.*?)</span>~', '[color=\\1]\\2[/color]', $string);
+		
+		// underline
+		$string = preg_replace('~<span style="text-decoration: underline;?">(.*?)</span>~', '[u]\\1[/u]', $string);
+		$string = str_ireplace('<u>', '[u]', $string);
+		$string = str_ireplace('</u>', '[/u]', $string);
+		
+		
+		// font size
+		$string = preg_replace('~<span style="font-size:(\d+)px;">(.*?)</span>~is', '[size=\\1]\\2[/size]', $string);
+		
+		// font color
+		$string = preg_replace('~<span style="color:(.*?);?">(.*?)</span>~is', '[color=\\1]\\2[/color]', $string);
+		
+		// sup and sub
+		$string = preg_replace('~<sup>(.*?)</sup>~is', '[sup]\\1[/sup]', $string);
+		$string = preg_replace('~<sub>(.*?)</sub>~is', '[sub]\\1[/sub]', $string);
+		
+		// align
+		$string = preg_replace('~<p style="text-align:(left|center|right);">(.*?)</p>~is', '[align=\\1]\\2[/align]', $string);
+		$string = preg_replace('~<p style="text-align: (left|center|right);">(.*?)</p>~is', '[align=\\1]\\2[/align]', $string);
+		$string = preg_replace('~(<p)\b[^>]*?(?=\h*\/?>)~','\1', $string);
+		
+		// remove attributes
+		$string = preg_replace('~(<table)\b[^>]*?(?=\h*\/?>)~','\1', $string);
+		$string = preg_replace('~(<article)\b[^>]*?(?=\h*\/?>)~','\1', $string);
+		$string = preg_replace('~(<tr)\b[^>]*?(?=\h*\/?>)~','\1', $string);
+		$string = preg_replace('~(<td)\b[^>]*?(?=\h*\/?>)~','\1', $string);
+		$string = preg_replace('~(<th)\b[^>]*?(?=\h*\/?>)~','\1', $string);
+		$string = preg_replace('~(<div)\b[^>]*?(?=\h*\/?>)~','\1', $string);
+		$string = preg_replace('~(<span)\b[^>]*?(?=\h*\/?>)~','\1', $string);
+		$string = preg_replace('~(<h1)\b[^>]*?(?=\h*\/?>)~','\1', $string);
+		$string = preg_replace('~(<h2)\b[^>]*?(?=\h*\/?>)~','\1', $string);
+		$string = preg_replace('~(<h3)\b[^>]*?(?=\h*\/?>)~','\1', $string);
+		$string = preg_replace('~(<h4)\b[^>]*?(?=\h*\/?>)~','\1', $string);
+		$string = preg_replace('~(<h5)\b[^>]*?(?=\h*\/?>)~','\1', $string);
+		$string = preg_replace('~(<h6)\b[^>]*?(?=\h*\/?>)~','\1', $string);
+		
+		// get the rest of them
+		$string = preg_replace('#\s(wmode|allowfullscreen|rel|data-hovercard|data-ft|target|id|title|alt|colspan|feature|scrolling|scope|width|height|bgcolor|cellspacing|frameborder|tabindex|valign|border|cellpadding)="[^"]+"#', '', $string);
+		
+		// heading elements
+		$string = str_ireplace('<h1>', '[size=24][b]', $string);
+		$string = str_ireplace('</h1>', '[/size][/b]', $string);
+		$string = str_ireplace('<h2>', '[size=18][b]', $string);
+		$string = str_ireplace('</h2>', '[/size][/b]', $string);
+		$string = str_ireplace('<h3>', '[size=14][b]', $string);
+		$string = str_ireplace('</h3>', '[/size][/b]', $string);
+		$string = str_ireplace('<h4>', '[size=12][b]', $string);
+		$string = str_ireplace('</h4>', '[/size][/b]', $string);
+		$string = str_ireplace('<h5>', '[size=10][b]', $string);
+		$string = str_ireplace('</h5>', '[/size][/b]', $string);
+		$string = str_ireplace('<h6>', '[size=10][b]', $string);
+		$string = str_ireplace('</h6>', '[/size][/b]', $string);
+		
+		// remove obsolete code
+		$string = str_ireplace('<p>', '', $string);
+		$string = str_ireplace('</p>', '', $string);
+		$string = str_ireplace('<span>', '', $string);
+		$string = str_ireplace('</span>', '', $string);
+		$string = str_ireplace('<center>', '', $string);
+		$string = str_ireplace('</center>', '', $string);
+		$string = str_ireplace('<div>', '', $string);
+		$string = str_ireplace('</div>', '', $string);
+		$string = str_ireplace('<article>', '', $string);
+		$string = str_ireplace('</article>', '', $string);
+		$string = str_ireplace('<aside>', '', $string);
+		$string = str_ireplace('</aside>', '', $string);
+		$string = str_ireplace('<tbody>', '', $string);
+		$string = str_ireplace('</tbody>', '', $string);
+		$string = str_ireplace('<thead>', '', $string);
+		$string = str_ireplace('</thead>', '', $string);
+		$string = str_ireplace('<section>', '', $string);
+		$string = str_ireplace('</section>', '', $string);
+		
+		// tables
+		$string = str_ireplace('<table>', '[table]', $string);
+		$string = str_ireplace('</table>', '[/table]', $string);
+		$string = str_ireplace('<tr>', '[tr]', $string);
+		$string = str_ireplace('</tr>', '[/tr]', $string);
+		$string = str_ireplace('<td>', '[td]', $string);
+		$string = str_ireplace('</td>', '[/td]', $string);
+		$string = str_ireplace('<th>', '[td]', $string);
+		$string = str_ireplace('</th>', '[/td]', $string);
+		
+		// media
+		$string = str_ireplace('[embed]', '[media]', $string);
+		$string = str_ireplace('[/embed]', '[/media]', $string);
+		
+		// youtube
+		$string = preg_replace('~<iframe src="http(s)?://(m|www\.)?youtube\.com/embed/([a-zA-Z0-9_\-]+)"></iframe>~is', '[media]https://youtu.be/\\3[/media]', $string);
+		$string = preg_replace('~<iframe src="http(s)?://(m|www\.)?youtube\.com/embed/([a-zA-Z0-9_\-]+)" allowfullscreen=""></iframe>~is', '[media]https://youtu.be/\\3[/media]', $string);
+		$string = preg_replace('#http(s)?://(m|www\.)?youtube\.com/embed/([a-zA-Z0-9_\-]+)#i', '[media]https://youtu.be/\\3[/media]', $string);
+		$string = preg_replace('#http(s)?://(m|www\.)?youtube\.com/watch\?v=([a-zA-Z0-9_\-]+)#i', '[media]https://youtu.be/\\3[/media]', $string);
+		
+		// dailymotion
+		$string = preg_replace('#http(s)?://(www\.)?dailymotion\.com/embed/video/([a-zA-Z0-9_\-]+)#i', '[media]https://www.dailymotion.com/video/\\3[/media]', $string);
+		$string = preg_replace('#http(s)?://(www\.)?dailymotion\.com/video/([a-zA-Z0-9_\-]+)#i', '[media]https://www.dailymotion.com/video/\\3[/media]', $string);
+		
+		// vimeo
+		$string = preg_replace('~<iframe src="http(s)?://(www\.)?vimeo\.com/([\d]+)"></iframe>~is', '[media]https://vimeo.com/\\3[/media]', $string);
+		$string = preg_replace('#http(s)?://(www\.)?vimeo\.com/([\d]+)#i', '[media]https://vimeo.com/\\3[/media]', $string);
+		
+		// veoh
+		$string = preg_replace('#http(s)?://(www\.)?veoh\.com/watch/v([a-zA-Z0-9_\-]+)#i', '[media]http://www.veoh.com/watch/v\\3[/media]', $string);
+		
+		// souncloud 
+		$string = preg_replace('#http(s)?://(m|www\.)?soundcloud\.com/([a-z0-9_\-]+/[a-z0-9_\-]+)#i', '[media]https://soundcloud.com/\\3[/media]', $string);
+		
+		// caption (to do: remove caption image description)
+		$string = preg_replace('#\[caption[^\]]*\](.*?)\[/caption\]#i', '\\1', $string);
+		
+		// img
+		$string = preg_replace('/(class=["\'][^\'"]*)size-(full|medium|large|thumbnail)\s?/', '\\1', $string );
+		$string = preg_replace('/(class=["\'][^\'"]*)wp-image-([0-9]+)\s?/', '\\1', $string );
+		$string = preg_replace('/(class=["\'][^\'"]*)align(none|center)\s?/', '\\1', $string );
+		$string = preg_replace('~<img class="alignleft" src="(.*?)" />~', '[img=\'\\1\',left][/img]', $string);
+		$string = preg_replace('~<img class="alignright" src="(.*?)" />~', '[img=\'\\1\',right][/img]', $string);
+		$string = preg_replace('~<img src="(.*?)" class="alignleft" />~', '[img=\'\\1\',left][/img]', $string);
+		$string = preg_replace('~<img src="(.*?)" class="alignright" />~', '[img=\'\\1\',right][/img]', $string);
+		$string = preg_replace('~<img[^>]+src=["\']([^"\']+)["\'][^>]*/?>~is', '[img]\\1[/img]', $string);
+		
+		// mails
+		$string = preg_replace('~<a.*?href=(?:"|\')mailto:([^"]*)(?:"|\')>(.*?)</a>~is', '[email=\'\\1\']\\2[/email]', $string);
+		
+		// urls
+		$string = preg_replace('~<a.*?href=(?:"|\')([^"]*)(?:"|\')>(.*?)</a>~is', '[url=\'\\1\']\\2[/url]', $string);
+		
+		// still to do: soundcloud and youtube playlist, clipfish, github, ins, caption image description and all that embled object-stuff
+		// there's an issue (maybe just in the one article i saw) with some wikipedia links, other works fine?!?
+		// did I already said I hate this stuff?
+		// goodbye!
 		
 		return $string;
 	}

--- a/files/lib/system/exporter/WordPress3xExporter.class.php
+++ b/files/lib/system/exporter/WordPress3xExporter.class.php
@@ -417,7 +417,6 @@ class WordPress3xExporter extends AbstractExporter {
 	}
 	
 	private static function fixMessage($string) {
-		
 		// we wanna get rid of f*ckin html in articles, so we have to remove a lot of crap
 		// btw. I hate this stuff and I'm pretty sure a lot of ppl. could do this much better
 		// really guys, I have no idea what I'm doing
@@ -478,8 +477,7 @@ class WordPress3xExporter extends AbstractExporter {
 		$string = preg_replace('~<span style="text-decoration: underline;?">(.*?)</span>~', '[u]\\1[/u]', $string);
 		$string = str_ireplace('<u>', '[u]', $string);
 		$string = str_ireplace('</u>', '[/u]', $string);
-		
-		
+				
 		// font size
 		$string = preg_replace('~<span style="font-size:(\d+)px;">(.*?)</span>~is', '[size=\\1]\\2[/size]', $string);
 		

--- a/files/lib/system/exporter/WordPress3xExporter.class.php
+++ b/files/lib/system/exporter/WordPress3xExporter.class.php
@@ -457,15 +457,15 @@ class WordPress3xExporter extends AbstractExporter {
 		$string = str_ireplace('&nbsp;', '', $string);
 		
 		// bold
-		$string = preg_replace('~(<strong)\b[^>]*?(?=\h*\/?>)~','\1', $string);
+		$string = preg_replace('~(<strong)\b[^>]*?(?=\h*\/?>)~', '\1', $string);
 		$string = str_ireplace('<strong>', '[b]', $string);
 		$string = str_ireplace('</strong>', '[/b]', $string);
 		$string = str_ireplace('<b>', '[b]', $string);
 		$string = str_ireplace('</b>', '[/b]', $string);
 		
 		// italic
-		$string = preg_replace('~(<i)\b[^>]*?(?=\h*\/?>)~','\1', $string);
-		$string = preg_replace('~(<em)\b[^>]*?(?=\h*\/?>)~','\1', $string);
+		$string = preg_replace('~(<i)\b[^>]*?(?=\h*\/?>)~', '\1', $string);
+		$string = preg_replace('~(<em)\b[^>]*?(?=\h*\/?>)~', '\1', $string);
 		$string = str_ireplace('<em>', '[i]', $string);
 		$string = str_ireplace('</em>', '[/i]', $string);
 		$string = str_ireplace('<i>', '[i]', $string);
@@ -493,22 +493,22 @@ class WordPress3xExporter extends AbstractExporter {
 		// align
 		$string = preg_replace('~<p style="text-align:(left|center|right);">(.*?)</p>~is', '[align=\\1]\\2[/align]', $string);
 		$string = preg_replace('~<p style="text-align: (left|center|right);">(.*?)</p>~is', '[align=\\1]\\2[/align]', $string);
-		$string = preg_replace('~(<p)\b[^>]*?(?=\h*\/?>)~','\1', $string);
+		$string = preg_replace('~(<p)\b[^>]*?(?=\h*\/?>)~', '\1', $string);
 		
 		// remove attributes
-		$string = preg_replace('~(<table)\b[^>]*?(?=\h*\/?>)~','\1', $string);
-		$string = preg_replace('~(<article)\b[^>]*?(?=\h*\/?>)~','\1', $string);
-		$string = preg_replace('~(<tr)\b[^>]*?(?=\h*\/?>)~','\1', $string);
-		$string = preg_replace('~(<td)\b[^>]*?(?=\h*\/?>)~','\1', $string);
-		$string = preg_replace('~(<th)\b[^>]*?(?=\h*\/?>)~','\1', $string);
-		$string = preg_replace('~(<div)\b[^>]*?(?=\h*\/?>)~','\1', $string);
-		$string = preg_replace('~(<span)\b[^>]*?(?=\h*\/?>)~','\1', $string);
-		$string = preg_replace('~(<h1)\b[^>]*?(?=\h*\/?>)~','\1', $string);
-		$string = preg_replace('~(<h2)\b[^>]*?(?=\h*\/?>)~','\1', $string);
-		$string = preg_replace('~(<h3)\b[^>]*?(?=\h*\/?>)~','\1', $string);
-		$string = preg_replace('~(<h4)\b[^>]*?(?=\h*\/?>)~','\1', $string);
-		$string = preg_replace('~(<h5)\b[^>]*?(?=\h*\/?>)~','\1', $string);
-		$string = preg_replace('~(<h6)\b[^>]*?(?=\h*\/?>)~','\1', $string);
+		$string = preg_replace('~(<table)\b[^>]*?(?=\h*\/?>)~', '\1', $string);
+		$string = preg_replace('~(<article)\b[^>]*?(?=\h*\/?>)~', '\1', $string);
+		$string = preg_replace('~(<tr)\b[^>]*?(?=\h*\/?>)~', '\1', $string);
+		$string = preg_replace('~(<td)\b[^>]*?(?=\h*\/?>)~', '\1', $string);
+		$string = preg_replace('~(<th)\b[^>]*?(?=\h*\/?>)~', '\1', $string);
+		$string = preg_replace('~(<div)\b[^>]*?(?=\h*\/?>)~', '\1', $string);
+		$string = preg_replace('~(<span)\b[^>]*?(?=\h*\/?>)~', '\1', $string);
+		$string = preg_replace('~(<h1)\b[^>]*?(?=\h*\/?>)~', '\1', $string);
+		$string = preg_replace('~(<h2)\b[^>]*?(?=\h*\/?>)~', '\1', $string);
+		$string = preg_replace('~(<h3)\b[^>]*?(?=\h*\/?>)~', '\1', $string);
+		$string = preg_replace('~(<h4)\b[^>]*?(?=\h*\/?>)~', '\1', $string);
+		$string = preg_replace('~(<h5)\b[^>]*?(?=\h*\/?>)~', '\1', $string);
+		$string = preg_replace('~(<h6)\b[^>]*?(?=\h*\/?>)~', '\1', $string);
 		
 		// get the rest of them
 		$string = preg_replace('#\s(wmode|allowfullscreen|rel|data-hovercard|data-ft|target|id|title|alt|colspan|feature|scrolling|scope|width|height|bgcolor|cellspacing|frameborder|tabindex|valign|border|cellpadding)="[^"]+"#', '', $string);


### PR DESCRIPTION
In order to replace the WordPress HTML Codes with BBCODES of WCF:

More info within the thread:
https://community.woltlab.com/thread/247321-html-tags-in-bbcodes-umwandeln-beim-import-aus-wordpress