### PR TITLE
Fix IPB4 password import

### DIFF
--- a/files/lib/system/exporter/IPB4xExporter.class.php
+++ b/files/lib/system/exporter/IPB4xExporter.class.php
@@ -241,7 +241,7 @@ class IPB4xExporter extends AbstractExporter {
 				
 			// update password hash
 			if ($newUserID) {
-				$passwordUpdateStatement->execute(array('ipb3:'.$row['members_pass_hash'].':'.$row['members_pass_salt'], $newUserID));
+				$passwordUpdateStatement->execute(array('cryptMD5:'.$row['members_pass_hash'].':'.$row['members_pass_salt'], $newUserID));
 			}
 		}
 	}


### PR DESCRIPTION
As of IPB4, bcrypt is used for passwords.

The applied changes have been successfully tested using IPS Community Suite 4.1.11.