### PR TITLE
Use `null` instead of `''` as the password value before replacing the…

### DIFF
--- a/files/lib/system/exporter/IPB3xExporter.class.php
+++ b/files/lib/system/exporter/IPB3xExporter.class.php
@@ -199,7 +199,7 @@ class IPB3xExporter extends AbstractExporter {
 		while ($row = $statement->fetchArray()) {
 			$data = [
 				'username' => self::fixSubject($row['name']),
-				'password' => '',
+				'password' => null,
 				'email' => $row['email'],
 				'registrationDate' => $row['joined'],
 				'banned' => $row['member_banned'],

--- a/files/lib/system/exporter/IPB4xExporter.class.php
+++ b/files/lib/system/exporter/IPB4xExporter.class.php
@@ -203,7 +203,7 @@ class IPB4xExporter extends AbstractExporter {
 		while ($row = $statement->fetchArray()) {
 			$data = [
 				'username' => $row['name'],
-				'password' => '',
+				'password' => null,
 				'email' => $row['email'],
 				'registrationDate' => $row['joined'],
 				'banned' => $row['temp_ban'] == -1 ? 1 : 0,

--- a/files/lib/system/exporter/MyBB16xExporter.class.php
+++ b/files/lib/system/exporter/MyBB16xExporter.class.php
@@ -285,7 +285,7 @@ class MyBB16xExporter extends AbstractExporter {
 		while ($row = $statement->fetchArray()) {
 			$data = [
 				'username' => $row['username'],
-				'password' => '',
+				'password' => null,
 				'email' => $row['email'],
 				'registrationDate' => $row['regdate'],
 				'banned' => $row['banExpires'] === null ? 0 : 1,

--- a/files/lib/system/exporter/NodeBB0xRedisExporter.class.php
+++ b/files/lib/system/exporter/NodeBB0xRedisExporter.class.php
@@ -174,7 +174,7 @@ class NodeBB0xRedisExporter extends AbstractExporter {
 			
 			$data = [
 				'username' => $row['username'],
-				'password' => '',
+				'password' => null,
 				'email' => $row['email'],
 				'registrationDate' => intval($row['joindate'] / 1000),
 				'banned' => $row['banned'] ? 1 : 0,

--- a/files/lib/system/exporter/PhpBB31xExporter.class.php
+++ b/files/lib/system/exporter/PhpBB31xExporter.class.php
@@ -316,7 +316,7 @@ class PhpBB31xExporter extends AbstractExporter {
 		while ($row = $statement->fetchArray()) {
 			$data = [
 				'username' => StringUtil::decodeHTML($row['username']),
-				'password' => '',
+				'password' => null,
 				'email' => $row['user_email'],
 				'registrationDate' => $row['user_regdate'],
 				'banned' => $row['banReason'] === null ? 0 : 1,

--- a/files/lib/system/exporter/PhpBB3xExporter.class.php
+++ b/files/lib/system/exporter/PhpBB3xExporter.class.php
@@ -304,7 +304,7 @@ class PhpBB3xExporter extends AbstractExporter {
 		while ($row = $statement->fetchArray()) {
 			$data = [
 				'username' => StringUtil::decodeHTML($row['username']),
-				'password' => '',
+				'password' => null,
 				'email' => $row['user_email'],
 				'registrationDate' => $row['user_regdate'],
 				'banned' => $row['banReason'] === null ? 0 : 1,

--- a/files/lib/system/exporter/SMF2xExporter.class.php
+++ b/files/lib/system/exporter/SMF2xExporter.class.php
@@ -306,7 +306,7 @@ class SMF2xExporter extends AbstractExporter {
 		while ($row = $statement->fetchArray()) {
 			$data = [
 				'username' => $row['member_name'],
-				'password' => '',
+				'password' => null,
 				'email' => $row['email_address'],
 				'registrationDate' => $row['date_registered'],
 				'banned' => ($row['ban_time'] && $row['banExpire'] === null) ? 1 : 0, // only permabans are imported

--- a/files/lib/system/exporter/VB3or4xExporter.class.php
+++ b/files/lib/system/exporter/VB3or4xExporter.class.php
@@ -400,7 +400,7 @@ class VB3or4xExporter extends AbstractExporter {
 		while ($row = $statement->fetchArray()) {
 			$data = [
 				'username' => StringUtil::decodeHTML($row['username']),
-				'password' => '',
+				'password' => null,
 				'email' => StringUtil::decodeHTML($row['email']),
 				'registrationDate' => $row['joindate'],
 				'banned' => $row['liftdate'] !== null && $row['liftdate'] == 0 ? 1 : 0,

--- a/files/lib/system/exporter/VB5xExporter.class.php
+++ b/files/lib/system/exporter/VB5xExporter.class.php
@@ -283,7 +283,7 @@ class VB5xExporter extends AbstractExporter {
 		while ($row = $statement->fetchArray()) {
 			$data = [
 				'username' => $row['username'],
-				'password' => '',
+				'password' => null,
 				'email' => $row['email'],
 				'registrationDate' => $row['joindate'],
 				'banned' => $row['liftdate'] !== null && $row['liftdate'] == 0 ? 1 : 0,

--- a/files/lib/system/exporter/WBB2xExporter.class.php
+++ b/files/lib/system/exporter/WBB2xExporter.class.php
@@ -280,7 +280,7 @@ class WBB2xExporter extends AbstractExporter {
 		while ($row = $statement->fetchArray()) {
 			$data = [
 				'username' => $row['username'],
-				'password' => '',
+				'password' => null,
 				'email' => $row['email'],
 				'registrationDate' => $row['regdate'],
 				'signature' => self::fixBBCodes($row['signature']),

--- a/files/lib/system/exporter/WBB3xExporter.class.php
+++ b/files/lib/system/exporter/WBB3xExporter.class.php
@@ -422,7 +422,7 @@ class WBB3xExporter extends AbstractExporter {
 		while ($row = $statement->fetchArray()) {
 			$data = [
 				'username' => $row['username'],
-				'password' => '',
+				'password' => null,
 				'email' => $row['email'],
 				'registrationDate' => $row['registrationDate'],
 				'banned' => $row['banned'],

--- a/files/lib/system/exporter/WBB4xExporter.class.php
+++ b/files/lib/system/exporter/WBB4xExporter.class.php
@@ -538,7 +538,7 @@ class WBB4xExporter extends AbstractExporter {
 		while ($row = $statement->fetchArray()) {
 			$data = [
 				'username' => $row['username'],
-				'password' => '',
+				'password' => null,
 				'email' => $row['email'],
 				'registrationDate' => $row['registrationDate'],
 				'banned' => $row['banned'],

--- a/files/lib/system/exporter/WordPress3xExporter.class.php
+++ b/files/lib/system/exporter/WordPress3xExporter.class.php
@@ -149,7 +149,7 @@ class WordPress3xExporter extends AbstractExporter {
 		while ($row = $statement->fetchArray()) {
 			$data = [
 				'username' => $row['user_login'],
-				'password' => '',
+				'password' => null,
 				'email' => $row['user_email'],
 				'registrationDate' => @strtotime($row['user_registered'])
 			];

--- a/files/lib/system/exporter/XF12xExporter.class.php
+++ b/files/lib/system/exporter/XF12xExporter.class.php
@@ -282,7 +282,7 @@ class XF12xExporter extends AbstractExporter {
 		while ($row = $statement->fetchArray()) {
 			$data = [
 				'username' => $row['username'],
-				'password' => '',
+				'password' => null,
 				'email' => $row['email'],
 				'registrationDate' => $row['register_date'],
 				'banned' => $row['is_banned'] ? 1 : 0,

--- a/files/lib/system/exporter/XF2xExporter.class.php
+++ b/files/lib/system/exporter/XF2xExporter.class.php
@@ -287,7 +287,7 @@ class XF2xExporter extends AbstractExporter {
 		while ($row = $statement->fetchArray()) {
 			$data = [
 				'username' => $row['username'],
-				'password' => '',
+				'password' => null,
 				'email' => $row['email'],
 				'registrationDate' => $row['register_date'],
 				'banned' => $row['is_banned'] ? 1 : 0,

--- a/files/lib/system/exporter/XoborExporter.class.php
+++ b/files/lib/system/exporter/XoborExporter.class.php
@@ -122,7 +122,7 @@ class XoborExporter extends AbstractExporter {
 		while ($row = $statement->fetchArray()) {
 			$data = [
 				'username' => StringUtil::decodeHTML($row['name']),
-				'password' => '',
+				'password' => null,
 				'email' => $row['mail'],
 				'registrationDate' => strtotime($row['reged']),
 				'signature' => self::fixMessage($row['signature_editable']),


### PR DESCRIPTION
… hash

This will result in a hash of `invalid:` and thus prevent login without
Exceptions.

Fixes #41

-----

Instead of adding an update statement with a hardcoded `invalid:` to Xobor I instead opted to consistently use `null` as the default in every importer.

see: https://github.com/WoltLab/WCF/blob/b87b53c2354cbecdf4db46efc17d4ca28f9181f7/wcfsetup/install/files/lib/data/user/UserEditor.class.php#L42-L49