### PR TITLE
add flag to detect whether an instance number is used

### DIFF
--- a/files/lib/system/exporter/WBB3xExporter.class.php
+++ b/files/lib/system/exporter/WBB3xExporter.class.php
@@ -23,8 +23,8 @@ use wcf\util\UserUtil;
 class WBB3xExporter extends AbstractExporter {
 	
 	/**
-	 * Has the installation been made with a db number?
-	 * Old installations can have a prefix like wbb1_ where 1 is the instance number
+	 * Has the installation been made with an instance number?
+	 * Old installations can have a prefix like wbb1_ only where 1 is the instance number
 	 * @var bool 
 	 */
 	protected $hasInstanceNumber = true;


### PR DESCRIPTION
I found some installations of the board in a early 3.0 or 3.1 version which do not have tables in the following format: wbb1_1_ Instead the WBB_N = 2 in the wcf/config.inc.php lead to table names in the following format wbb2_

This should actually be considered the instance number but the database number in this exporter is always connected to the wbb or blog prefix, so I used that instead.